### PR TITLE
Fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="https://raw.githubusercontent.com/CodeSandwich/mocktopus/master/logo.png" alt="logo"/>
 </p>
 
-Mocking framework for Rust (currently only nightly). See [documentation](https://docs.rs/crate/mocktopus) for more.
+Mocking framework for Rust (currently only nightly). See [documentation](https://docs.rs/mocktopus/0.4.1/mocktopus/) for more.
 
 ```rust
 #[mockable]

--- a/crates_io_readme.md
+++ b/crates_io_readme.md
@@ -1,6 +1,6 @@
 ![logo](https://raw.githubusercontent.com/CodeSandwich/mocktopus/master/logo.png)
 
-Mocking framework for Rust (currently only nightly). See documentation for more.
+Mocking framework for Rust (currently only nightly). See [documentation](https://docs.rs/mocktopus/0.4.1/mocktopus/) for more.
 
 ```rust
 #[mockable]


### PR DESCRIPTION
Use latest version of documentation that built on doc.rs (0.4.1)
Fixes #25