### PR TITLE
Stop using outdated feature gates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //! Enable procedural macros in crate root:
 //!
 //! ```
-//! #![cfg_attr(test, feature(proc_macro_mod))]
+//! #![cfg_attr(test, feature(proc_macro_hygiene))]
 //! ```
 //! Import Mocktopus:
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(fn_traits, get_type_id, unboxed_closures, use_extern_macros)]
+#![feature(fn_traits, get_type_id, unboxed_closures)]
 
 //! Mocking framework for Rust (currently only nightly)
 //!
@@ -38,7 +38,7 @@
 //! Enable procedural macros in crate root:
 //!
 //! ```
-//! #![cfg_attr(test, feature(proc_macro_mod, use_extern_macros))]
+//! #![cfg_attr(test, feature(proc_macro_mod))]
 //! ```
 //! Import Mocktopus:
 //!

--- a/tests/injecting.rs
+++ b/tests/injecting.rs
@@ -1,4 +1,4 @@
-#![feature(const_fn, proc_macro_gen, proc_macro_mod, use_extern_macros)]
+#![feature(const_fn, proc_macro_gen, proc_macro_mod)]
 
 // Test if injecting works even if mocktopus is aliased
 extern crate mocktopus as mocktopus_aliased;

--- a/tests/injecting.rs
+++ b/tests/injecting.rs
@@ -1,4 +1,4 @@
-#![feature(const_fn, proc_macro_gen, proc_macro_mod)]
+#![feature(const_fn, proc_macro_hygiene)]
 
 // Test if injecting works even if mocktopus is aliased
 extern crate mocktopus as mocktopus_aliased;

--- a/tests/injecting_no_std.rs
+++ b/tests/injecting_no_std.rs
@@ -1,4 +1,3 @@
-#![feature(use_extern_macros)]
 #![no_std]
 
 extern crate mocktopus;

--- a/tests/mocking.rs
+++ b/tests/mocking.rs
@@ -1,5 +1,3 @@
-#![feature(use_extern_macros)]
-
 extern crate mocktopus;
 
 mod mocking_fns;


### PR DESCRIPTION
This feature was stabilized in Rust 1.30.0?

See https://github.com/rust-lang/rust/pull/50911/, and [the release notes for 1.30.0](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1300-2018-10-25) which include that PR.

See also https://github.com/rust-lang/rust/commit/d3c902f3113575b134641c14a9734b5075d06b09, which merged the `proc_macro_*` macros into one `proc_macro_hygiene` feature gate.