### PR TITLE
Multiple mocks

### DIFF
--- a/tests/injecting.rs
+++ b/tests/injecting.rs
@@ -1,4 +1,4 @@
-#![feature(const_fn, proc_macro_gen, proc_macro_mod, use_extern_macros)]
+#![feature(const_fn, proc_macro_hygiene, use_extern_macros)]
 
 // Test if injecting works even if mocktopus is aliased
 extern crate mocktopus as mocktopus_aliased;

--- a/tests/mocking.rs
+++ b/tests/mocking.rs
@@ -203,3 +203,26 @@ mod mock_closures_can_mutate_their_state {
         assert_eq!("other mock", function());
     }
 }
+
+mod multiple_mocks_can_be_defined {
+    use super::*;
+
+    #[mockable]
+    fn function() -> &'static str {
+        "not mocked"
+    }
+
+    #[test]
+    fn when_not_mocked_then_runs_normally() {
+        assert_eq!("not mocked", function());
+    }
+
+    #[test]
+    fn when_mocked_then_runs_mocks_with_state() {
+        function.mock_safe(|| MockResult::Return("first mock"));
+        function.mock_safe(|| MockResult::Return("other mock"));
+
+        assert_eq!("first mock", function());
+        assert_eq!("other mock", function());
+    }
+}

--- a/tests/mocking.rs
+++ b/tests/mocking.rs
@@ -175,34 +175,6 @@ mod mocking_trait_default_for_struct_does_not_mock_same_default_for_another_stru
     }
 }
 
-mod mock_closures_can_mutate_their_state {
-    use super::*;
-
-    #[mockable]
-    fn function() -> &'static str {
-        "not mocked"
-    }
-
-    #[test]
-    fn when_not_mocked_then_runs_normally() {
-        assert_eq!("not mocked", function());
-    }
-
-    #[test]
-    fn when_mocked_then_runs_mocks_with_state() {
-        let mut x = 0;
-        function.mock_safe(move || {
-            x += 1;
-            match x {
-                1 => MockResult::Return("first mock"),
-                _ => MockResult::Return("other mock"),
-            }
-        });
-
-        assert_eq!("first mock", function());
-        assert_eq!("other mock", function());
-    }
-}
 
 mod multiple_mocks_can_be_defined {
     use super::*;


### PR DESCRIPTION
Hello,
I have added the ability to run `mock_safe` multiple times on the same function. Each call to `mock_safe` mocks exactly one call of the mocked function in provided order. This provides the user a more elegent way than manually increment a counter to mock different calls to the same function.

BTW: I'm a big fan of how you have been able to add the functionality to mock functions!