### PR TITLE
Replace get_type_id with type_id

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(fn_traits, get_type_id, unboxed_closures, use_extern_macros)]
+#![feature(fn_traits, unboxed_closures, use_extern_macros)]
 
 //! Mocking framework for Rust (currently only nightly)
 //!

--- a/src/mocking.rs
+++ b/src/mocking.rs
@@ -121,6 +121,6 @@ impl<T, O, F: FnOnce<T, Output=O>> Mockable<T, O> for F {
     }
 
     unsafe fn get_mock_id(&self) -> TypeId {
-        (||()).get_type_id()
+        (||()).type_id()
     }
 }


### PR DESCRIPTION
In rust 1.33.0, get_type_id was stabilized and renamed to type_id

Fixes #36