### PR TITLE
Add fn to manually clear all mocks

### DIFF
--- a/src/mocking.rs
+++ b/src/mocking.rs
@@ -87,6 +87,13 @@ thread_local!{
     static MOCK_STORE: RefCell<HashMap<TypeId, Rc<RefCell<Box<FnMut<(), Output=()>>>>>> = RefCell::new(HashMap::new())
 }
 
+/// Clear all mocks in the ThreadLocal; only necessary if tests share threads
+pub fn clear_mocks() {
+    MOCK_STORE.with(|mock_ref_cell| {
+        mock_ref_cell.borrow_mut().clear();
+    });
+}
+
 impl<T, O, F: FnOnce<T, Output=O>> Mockable<T, O> for F {
     unsafe fn mock_raw<M: FnMut<T, Output=MockResult<T, O>>>(&self, mock: M) {
         let id = self.get_mock_id();

--- a/tests/mocking.rs
+++ b/tests/mocking.rs
@@ -314,3 +314,35 @@ mod creating_mock_inside_mock_closure {
         assert_eq!("mocked 1 mocked 2", mockable_1());
     }
 }
+
+mod clear_mocks {
+    use super::*;
+
+    #[mockable]
+    fn mockable_1() -> String {
+        "not mocked 1".to_string()
+    }
+
+    #[mockable]
+    fn mockable_2() -> String {
+        "not mocked 2".to_string()
+    }
+
+    #[test]
+    fn when_clearing_mocks_original_function_operations_return() {
+        mockable_1.mock_safe(|| {
+            MockResult::Return("mocked 1".to_string())
+        });
+        mockable_2.mock_safe(|| {
+            MockResult::Return("mocked 2".to_string())
+        });
+
+        assert_eq!("mocked 1", mockable_1());
+        assert_eq!("mocked 2", mockable_2());
+
+        clear_mocks();
+
+        assert_eq!("not mocked 1", mockable_1());
+        assert_eq!("not mocked 2", mockable_2());
+    }
+}


### PR DESCRIPTION
While it's generally true that all rust tests run in separate threads, there are some circumstances where you need them to run in the same thread (testing functions that interact with dpdk, for example). We needed a quick way to clean up at the end of each test.

Happy to position this differently if you like -- also understand if this isn't a use case you want to incorporate.