### PR TITLE
Add clear_mock and mock_scoped methods to Mockable

### DIFF
--- a/tests/mocking.rs
+++ b/tests/mocking.rs
@@ -389,9 +389,7 @@ mod mock_context {
     #[test]
     fn test_run_restores_the_function() {
         MockContext::new()
-            .mock_safe(mockable_1, || {
-                    MockResult::Return(1)
-            })
+            .mock_safe(mockable_1, || MockResult::Return(1))
             .run(|| {});
         assert_eq!(mockable_1(), 0);
     }
@@ -401,6 +399,18 @@ mod mock_context {
         MockContext::new()
             .run(|| {
                 assert_eq!(mockable_1(), 0);
+            });
+        assert_eq!(mockable_1(), 0);
+    }
+
+    #[test]
+    fn test_mock_the_same_function_multiple_times() {
+        MockContext::new()
+            .mock_safe(mockable_1, || MockResult::Return(1))
+            .mock_safe(mockable_1, || MockResult::Return(2))
+            .mock_safe(mockable_1, || MockResult::Return(3))
+            .run(|| {
+                assert_eq!(mockable_1(), 3);
             });
         assert_eq!(mockable_1(), 0);
     }

--- a/tests/mocking.rs
+++ b/tests/mocking.rs
@@ -396,3 +396,44 @@ mod mock_scoped {
         assert_eq!(x, 1);
     }
 }
+
+mod mock_context {
+    use super::*;
+
+    #[mockable]
+    fn mockable_1() -> i32 { 0 }
+
+    #[test]
+    fn test_run_mocks_the_function() {
+        let mut x = 0;
+        MockContext::new()
+            .mock_safe(mockable_1, || {
+                x += 1;
+                MockResult::Return(1)
+            })
+            .run(|| {
+                assert_eq!(mockable_1(), 1);
+            });
+        assert_eq!(mockable_1(), 0);
+        assert_eq!(x, 1);
+    }
+
+    #[test]
+    fn test_run_restores_the_function() {
+        MockContext::new()
+            .mock_safe(mockable_1, || {
+                    MockResult::Return(1)
+            })
+            .run(|| {});
+        assert_eq!(mockable_1(), 0);
+    }
+
+    #[test]
+    fn test_run_no_mocks() {
+        MockContext::new()
+            .run(|| {
+                assert_eq!(mockable_1(), 0);
+            });
+        assert_eq!(mockable_1(), 0);
+    }
+}

--- a/tests/mocking.rs
+++ b/tests/mocking.rs
@@ -346,3 +346,21 @@ mod clear_mocks {
         assert_eq!("not mocked 2", mockable_2());
     }
 }
+
+mod clear_mock {
+    use super::*;
+
+    #[mockable]
+    fn mockable_1() -> i32 {
+        0
+    }
+
+    #[test]
+    fn clearing_deregisters_the_mock() {
+        mockable_1.mock_safe(|| MockResult::Return(1));
+        assert_eq!(mockable_1(), 1);
+
+        mockable_1.clear_mock();
+        assert_eq!(mockable_1(), 0);
+    }
+}

--- a/tests/mocking.rs
+++ b/tests/mocking.rs
@@ -365,38 +365,6 @@ mod clear_mock {
     }
 }
 
-mod mock_scoped {
-    use super::*;
-
-    #[mockable]
-    fn mockable_1() -> i32 {
-        0
-    }
-
-    #[test]
-    fn dropping_the_scope_deregisters_the_mock() {
-        {
-            let _scope = unsafe { mockable_1.mock_scoped(|| MockResult::Return(1)) };
-            assert_eq!(mockable_1(), 1);
-        }
-
-        assert_eq!(mockable_1(), 0);
-    }
-
-    #[test]
-    fn can_use_local_variables_safely() {
-        let mut x = 0;
-        {
-            let _scope = unsafe { mockable_1.mock_scoped(|| {
-                x += 1;
-                MockResult::Return(1)
-            }) };
-            mockable_1();
-        }
-        assert_eq!(x, 1);
-    }
-}
-
 mod mock_context {
     use super::*;
 

--- a/tests/mocking.rs
+++ b/tests/mocking.rs
@@ -364,3 +364,35 @@ mod clear_mock {
         assert_eq!(mockable_1(), 0);
     }
 }
+
+mod mock_scoped {
+    use super::*;
+
+    #[mockable]
+    fn mockable_1() -> i32 {
+        0
+    }
+
+    #[test]
+    fn dropping_the_scope_deregisters_the_mock() {
+        {
+            let _scope = mockable_1.mock_scoped(|| MockResult::Return(1));
+            assert_eq!(mockable_1(), 1);
+        }
+
+        assert_eq!(mockable_1(), 0);
+    }
+
+    #[test]
+    fn can_use_local_variables_safely() {
+        let mut x = 0;
+        {
+            let _scope = mockable_1.mock_scoped(|| {
+                x += 1;
+                MockResult::Return(1)
+            });
+            mockable_1();
+        }
+        assert_eq!(x, 1);
+    }
+}

--- a/tests/mocking.rs
+++ b/tests/mocking.rs
@@ -376,7 +376,7 @@ mod mock_scoped {
     #[test]
     fn dropping_the_scope_deregisters_the_mock() {
         {
-            let _scope = mockable_1.mock_scoped(|| MockResult::Return(1));
+            let _scope = unsafe { mockable_1.mock_scoped(|| MockResult::Return(1)) };
             assert_eq!(mockable_1(), 1);
         }
 
@@ -387,10 +387,10 @@ mod mock_scoped {
     fn can_use_local_variables_safely() {
         let mut x = 0;
         {
-            let _scope = mockable_1.mock_scoped(|| {
+            let _scope = unsafe { mockable_1.mock_scoped(|| {
                 x += 1;
                 MockResult::Return(1)
-            });
+            }) };
             mockable_1();
         }
         assert_eq!(x, 1);


### PR DESCRIPTION
These routines allow for more control over an individual mock.

`clear_mock` will remove that mock.  This functions as the individual analog to `clear_mocks`.

`mock_scoped` allows for safe usage of local variables by implementing functionality similar to a [`MutexGuard`](https://doc.rust-lang.org/std/sync/struct.MutexGuard.html).