### PR TITLE
transform async methods for mocking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,10 @@ travis-ci = { repository = "CodeSandwich/Mocktopus" }
 doctest = false
 
 [dependencies]
-mocktopus_macros = "=0.7.5"
+mocktopus_macros = { path = "macros"}
+
+[dev-dependencies]
+tokio = { version = "0.2", features = ["full"] }
 
 [workspace]
 members = ["macros"]

--- a/macros/src/item_injector.rs
+++ b/macros/src/item_injector.rs
@@ -278,7 +278,10 @@ fn inject_any_fn(
             }
         }
         fn_decl.generics.params.push(parse_quote!('mocktopus));
-        where_clause.predicates.push(parse_quote!(Self: 'mocktopus));
+
+        if let Context::Impl { .. } = context {
+            where_clause.predicates.push(parse_quote!(Self: 'mocktopus));
+        }
 
         let ret = match &fn_decl.output {
             ReturnType::Default => quote!(()),

--- a/tests/mocking.rs
+++ b/tests/mocking.rs
@@ -2,6 +2,7 @@ extern crate mocktopus;
 
 mod mocking_fns;
 mod mocking_methods;
+mod mocking_methods_async;
 mod mocking_trait_defaults;
 mod mocking_traits;
 

--- a/tests/mocking_fns/mod.rs
+++ b/tests/mocking_fns/mod.rs
@@ -2,3 +2,4 @@ use super::*;
 
 mod when_fn_generic;
 mod when_fn_regular;
+mod when_fn_regular_async;

--- a/tests/mocking_fns/mod.rs
+++ b/tests/mocking_fns/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 
 mod when_fn_generic;
+mod when_fn_generic_async;
 mod when_fn_regular;
 mod when_fn_regular_async;

--- a/tests/mocking_fns/when_fn_generic_async.rs
+++ b/tests/mocking_fns/when_fn_generic_async.rs
@@ -1,0 +1,34 @@
+use super::*;
+
+#[mockable]
+async fn function<T: Display + Send>(arg: bool, fn_generic: T) -> String {
+    format!("{} {}", arg, fn_generic)
+}
+
+#[tokio::test]
+async fn and_not_mocked_then_runs_normally() {
+    assert_eq!("true 2.5", function(true, 2.5f32).await);
+    assert_eq!("true abc", function(true, "abc").await);
+}
+
+#[tokio::test]
+async fn and_continue_mocked_then_runs_with_modified_args_for_mocked_type_only() {
+    unsafe {
+        function::<f32>.mock_raw(|a, b| MockResult::Continue((!a, b + 1.)));
+    }
+
+    assert_eq!("false 3.5", function(true, 2.5f32).await);
+    assert_eq!("true abc", function(true, "abc").await);
+}
+
+#[tokio::test]
+async fn and_return_mocked_then_returns_mocking_result_for_mocked_type_only() {
+    unsafe {
+        function::<f32>.mock_raw(|a, b| {
+            MockResult::Return(Box::pin(async move { format!("mocked {} {}", a, b) }))
+        });
+    }
+
+    assert_eq!("mocked true 2.5", function(true, 2.5f32).await);
+    assert_eq!("true abc", function(true, "abc").await);
+}

--- a/tests/mocking_fns/when_fn_regular_async.rs
+++ b/tests/mocking_fns/when_fn_regular_async.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+#[mockable]
+async fn function(arg: bool) -> String {
+    format!("{}", arg)
+}
+
+#[tokio::test]
+async fn and_not_mocked_then_runs_normally() {
+    assert_eq!("true", function(true).await);
+}
+
+#[tokio::test]
+async fn and_continue_mocked_then_runs_with_modified_args() {
+    unsafe {
+        function.mock_raw(|a| MockResult::Continue((!a,)));
+    }
+
+    assert_eq!("false", function(true).await);
+}
+
+#[tokio::test]
+async fn and_return_mocked_then_returns_mocking_result() {
+    unsafe {
+        function.mock_raw(|a| MockResult::Return(Box::pin(async move { format!("mocked {}", a) })));
+    }
+
+    assert_eq!("mocked true", function(true).await);
+}

--- a/tests/mocking_methods_async/mod.rs
+++ b/tests/mocking_methods_async/mod.rs
@@ -1,0 +1,3 @@
+use super::*;
+
+mod when_struct_regular_method_regular_async;

--- a/tests/mocking_methods_async/mod.rs
+++ b/tests/mocking_methods_async/mod.rs
@@ -1,3 +1,6 @@
 use super::*;
 
+mod when_struct_generic_method_generic_async;
+mod when_struct_generic_method_regular_async;
+mod when_struct_regular_method_generic_async;
 mod when_struct_regular_method_regular_async;

--- a/tests/mocking_methods_async/when_struct_generic_method_generic_async.rs
+++ b/tests/mocking_methods_async/when_struct_generic_method_generic_async.rs
@@ -1,0 +1,217 @@
+use super::*;
+
+struct Struct<T>(T);
+
+#[mockable]
+impl<T: Display + Default + Send + Sync> Struct<T> {
+    async fn static_method<U: Display + Send>(arg: bool, method_generic: U) -> String {
+        format!("{} {}", arg, method_generic)
+    }
+
+    async fn ref_method<U: Display + Send>(&self, arg: bool, method_generic: U) -> String {
+        format!("{} {} {}", self.0, arg, method_generic)
+    }
+
+    async fn ref_mut_method<U: Display + Send>(&mut self, arg: bool, method_generic: U) -> String {
+        self.0 = T::default();
+        format!("{} {} {}", self.0, arg, method_generic)
+    }
+
+    async fn val_method<U: Display + Send>(self, arg: bool, method_generic: U) -> String {
+        format!("{} {} {}", self.0, arg, method_generic)
+    }
+}
+
+mod and_method_is_static {
+    use super::*;
+
+    #[tokio::test]
+    async fn and_not_mocked_then_runs_normally() {
+        assert_eq!("true 2.5", Struct::<u8>::static_method(true, 2.5f32).await);
+        assert_eq!("true abc", Struct::<u8>::static_method(true, "abc").await);
+        assert_eq!(
+            "true 2.5",
+            Struct::<&str>::static_method(true, 2.5f32).await
+        );
+    }
+
+    #[tokio::test]
+    async fn and_continue_mocked_then_runs_with_modified_args_for_mocked_type_only() {
+        unsafe {
+            Struct::<u8>::static_method::<f32>.mock_raw(|a, b| MockResult::Continue((!a, b + 1.)));
+        }
+
+        assert_eq!("false 3.5", Struct::<u8>::static_method(true, 2.5f32).await);
+        assert_eq!("true abc", Struct::<u8>::static_method(true, "abc").await);
+        assert_eq!(
+            "true 2.5",
+            Struct::<&str>::static_method(true, 2.5f32).await
+        );
+    }
+
+    #[tokio::test]
+    async fn and_return_mocked_then_returns_mocking_result_for_mocked_type_only() {
+        unsafe {
+            Struct::<u8>::static_method::<f32>.mock_raw(|a, b| {
+                MockResult::Return(Box::pin(async move { format!("mocked {} {}", a, b) }))
+            });
+        }
+
+        assert_eq!(
+            "mocked true 2.5",
+            Struct::<u8>::static_method(true, 2.5f32).await
+        );
+        assert_eq!("true abc", Struct::<u8>::static_method(true, "abc").await);
+        assert_eq!(
+            "true 2.5",
+            Struct::<&str>::static_method(true, 2.5f32).await
+        );
+    }
+}
+
+mod and_method_is_ref_method {
+    use super::*;
+
+    #[tokio::test]
+    async fn and_not_mocked_then_runs_normally() {
+        assert_eq!("2 true 1.5", Struct(2u8).ref_method(true, 1.5f32).await);
+        assert_eq!("2 true abc", Struct(2u8).ref_method(true, "abc").await);
+        assert_eq!("abc true 1.5", Struct("abc").ref_method(true, 1.5f32).await);
+    }
+
+    #[tokio::test]
+    async fn and_continue_mocked_then_runs_with_modified_args() {
+        let struct_2 = Struct(2u8);
+        let struct_3 = Struct(3u8);
+        unsafe {
+            Struct::<u8>::ref_method::<f32>
+                .mock_raw(|_, b, c| MockResult::Continue((&struct_3, !b, c + 1.)));
+        }
+
+        assert_eq!("3 false 2.5", struct_2.ref_method(true, 1.5f32).await);
+        assert_eq!(2, struct_2.0);
+        assert_eq!(3, struct_3.0);
+        assert_eq!("2 true abc", Struct(2u8).ref_method(true, "abc").await);
+        assert_eq!("abc true 1.5", Struct("abc").ref_method(true, 1.5f32).await);
+    }
+
+    #[tokio::test]
+    async fn and_return_mocked_then_returns_mocking_result() {
+        let struct_2 = Struct(2u8);
+        unsafe {
+            Struct::<u8>::ref_method::<f32>.mock_raw(|a, b, c| {
+                MockResult::Return(Box::pin(
+                    async move { format!("mocked {} {} {}", a.0, b, c) },
+                ))
+            });
+        }
+
+        assert_eq!("mocked 2 true 1.5", struct_2.ref_method(true, 1.5f32).await);
+        assert_eq!(2, struct_2.0);
+        assert_eq!("2 true abc", Struct(2).ref_method(true, "abc").await);
+        assert_eq!("abc true 1.5", Struct("abc").ref_method(true, 1.5f32).await);
+    }
+}
+
+mod and_method_is_ref_mut_method {
+    use super::*;
+
+    #[tokio::test]
+    async fn and_not_mocked_then_runs_normally() {
+        let mut struct_2 = Struct(2u8);
+        let mut struct_4 = Struct(4u8);
+        let mut struct_str = Struct("abc");
+
+        assert_eq!("0 true 1.5", struct_2.ref_mut_method(true, 1.5f32).await);
+        assert_eq!(0, struct_2.0);
+        assert_eq!("0 true abc", struct_4.ref_mut_method(true, "abc").await);
+        assert_eq!(0, struct_4.0);
+        assert_eq!(" true 1.5", struct_str.ref_mut_method(true, 1.5).await);
+        assert_eq!("", struct_str.0);
+    }
+
+    #[tokio::test]
+    async fn and_continue_mocked_then_runs_with_modified_args() {
+        let mut struct_2 = Struct(2u8);
+        let struct_3 = Struct(3u8);
+        let mut struct_4 = Struct(4u8);
+        let mut struct_str = Struct("abc");
+        unsafe {
+            Struct::<u8>::ref_mut_method::<f32>
+                .mock_raw(|_, b, c| MockResult::Continue((as_mut(&struct_3), !b, c + 1.)));
+        }
+
+        assert_eq!("0 false 2.5", struct_2.ref_mut_method(true, 1.5f32).await);
+        assert_eq!(2, struct_2.0);
+        assert_eq!(0, struct_3.0);
+        assert_eq!("0 true abc", struct_4.ref_mut_method(true, "abc").await);
+        assert_eq!(0, struct_4.0);
+        assert_eq!(" true 1.5", struct_str.ref_mut_method(true, 1.5).await);
+        assert_eq!("", struct_str.0);
+    }
+
+    #[tokio::test]
+    async fn and_return_mocked_then_returns_mocking_result() {
+        let mut struct_2 = Struct(2u8);
+        let mut struct_4 = Struct(4u8);
+        let mut struct_str = Struct("abc");
+        unsafe {
+            Struct::<u8>::ref_mut_method::<f32>.mock_raw(|a, b, c| {
+                MockResult::Return(Box::pin(
+                    async move { format!("mocked {} {} {}", a.0, b, c) },
+                ))
+            });
+        }
+
+        assert_eq!(
+            "mocked 2 true 1.5",
+            struct_2.ref_mut_method(true, 1.5f32).await
+        );
+        assert_eq!(2, struct_2.0);
+        assert_eq!("0 true abc", struct_4.ref_mut_method(true, "abc").await);
+        assert_eq!(0, struct_4.0);
+        assert_eq!(" true 1.5", struct_str.ref_mut_method(true, 1.5).await);
+        assert_eq!("", struct_str.0);
+    }
+}
+
+mod and_method_is_val_method {
+    use super::*;
+
+    #[tokio::test]
+    async fn and_not_mocked_then_runs_normally() {
+        assert_eq!("2 true 1.5", Struct(2u8).val_method(true, 1.5f32).await);
+        assert_eq!("2 true abc", Struct(2u8).val_method(true, "abc").await);
+        assert_eq!("abc true 1.5", Struct("abc").val_method(true, 1.5f32).await);
+    }
+
+    #[tokio::test]
+    async fn and_continue_mocked_then_runs_with_modified_args() {
+        unsafe {
+            Struct::<u8>::val_method::<f32>
+                .mock_raw(move |_, b, c| MockResult::Continue((Struct(3u8), !b, c + 1.)));
+        }
+
+        assert_eq!("3 false 2.5", Struct(2u8).val_method(true, 1.5f32).await);
+        assert_eq!("2 true abc", Struct(2u8).val_method(true, "abc").await);
+        assert_eq!("abc true 1.5", Struct("abc").val_method(true, 1.5f32).await);
+    }
+
+    #[tokio::test]
+    async fn and_return_mocked_then_returns_mocking_result() {
+        unsafe {
+            Struct::<u8>::val_method::<f32>.mock_raw(|a, b, c| {
+                MockResult::Return(Box::pin(
+                    async move { format!("mocked {} {} {}", a.0, b, c) },
+                ))
+            });
+        }
+
+        assert_eq!(
+            "mocked 2 true 1.5",
+            Struct(2u8).val_method(true, 1.5f32).await
+        );
+        assert_eq!("2 true abc", Struct(2u8).val_method(true, "abc").await);
+        assert_eq!("abc true 1.5", Struct("abc").val_method(true, 1.5f32).await);
+    }
+}

--- a/tests/mocking_methods_async/when_struct_generic_method_regular_async.rs
+++ b/tests/mocking_methods_async/when_struct_generic_method_regular_async.rs
@@ -1,0 +1,172 @@
+use super::*;
+
+struct Struct<T>(T);
+
+#[mockable]
+impl<T: Display + Default + Send + Sync> Struct<T> {
+    async fn static_method(arg: bool) -> String {
+        format!("{}", arg)
+    }
+
+    async fn ref_method(&self, arg: bool) -> String {
+        format!("{} {}", self.0, arg)
+    }
+
+    async fn ref_mut_method(&mut self, arg: bool) -> String {
+        self.0 = T::default();
+        format!("{} {}", self.0, arg)
+    }
+
+    async fn val_method(self, arg: bool) -> String {
+        format!("{} {}", self.0, arg)
+    }
+}
+
+mod and_method_is_static {
+    use super::*;
+
+    #[tokio::test]
+    async fn and_not_mocked_then_runs_normally() {
+        assert_eq!("true", Struct::<u8>::static_method(true).await);
+        assert_eq!("true", Struct::<&str>::static_method(true).await);
+    }
+
+    #[tokio::test]
+    async fn and_continue_mocked_then_runs_with_modified_args_for_mocked_type_only() {
+        unsafe {
+            Struct::<u8>::static_method.mock_raw(|a| MockResult::Continue((!a,)));
+        }
+
+        assert_eq!("false", Struct::<u8>::static_method(true).await);
+        assert_eq!("true", Struct::<&str>::static_method(true).await);
+    }
+
+    #[tokio::test]
+    async fn and_return_mocked_then_returns_mocking_result_for_mocked_type_only() {
+        unsafe {
+            Struct::<u8>::static_method
+                .mock_raw(|a| MockResult::Return(Box::pin(async move { format!("mocked {}", a) })));
+        }
+
+        assert_eq!("mocked true", Struct::<u8>::static_method(true).await);
+        assert_eq!("true", Struct::<&str>::static_method(true).await);
+    }
+}
+
+mod and_method_is_ref_method {
+    use super::*;
+
+    #[tokio::test]
+    async fn and_not_mocked_then_runs_normally() {
+        assert_eq!("2 true", Struct(2u8).ref_method(true).await);
+        assert_eq!("abc true", Struct("abc").ref_method(true).await);
+    }
+
+    #[tokio::test]
+    async fn and_continue_mocked_then_runs_with_modified_args() {
+        let struct_2 = Struct(2u8);
+        let struct_3 = Struct(3u8);
+        unsafe {
+            Struct::<u8>::ref_method.mock_raw(|_, b| MockResult::Continue((&struct_3, !b)));
+        }
+
+        assert_eq!("3 false", struct_2.ref_method(true).await);
+        assert_eq!(2, struct_2.0);
+        assert_eq!(3, struct_3.0);
+        assert_eq!("abc true", Struct("abc").ref_method(true).await);
+    }
+
+    #[tokio::test]
+    async fn and_return_mocked_then_returns_mocking_result() {
+        let struct_2 = Struct(2u8);
+        unsafe {
+            Struct::<u8>::ref_method.mock_raw(|a, b| {
+                MockResult::Return(Box::pin(async move { format!("mocked {} {}", a.0, b) }))
+            });
+        }
+
+        assert_eq!("mocked 2 true", struct_2.ref_method(true).await);
+        assert_eq!(2, struct_2.0);
+        assert_eq!("abc true", Struct("abc").ref_method(true).await);
+    }
+}
+
+mod and_method_is_ref_mut_method {
+    use super::*;
+
+    #[tokio::test]
+    async fn and_not_mocked_then_runs_normally() {
+        let mut struct_2 = Struct(2u8);
+        let mut struct_str = Struct("str");
+
+        assert_eq!("0 true", struct_2.ref_mut_method(true).await);
+        assert_eq!(0, struct_2.0);
+        assert_eq!(" true", struct_str.ref_mut_method(true).await);
+        assert_eq!("", struct_str.0);
+    }
+
+    #[tokio::test]
+    async fn and_continue_mocked_then_runs_with_modified_args() {
+        let mut struct_2 = Struct(2u8);
+        let struct_3 = Struct(3u8);
+        let mut struct_str = Struct("str");
+        unsafe {
+            Struct::<u8>::ref_mut_method
+                .mock_raw(|_, b| MockResult::Continue((as_mut(&struct_3), !b)));
+        }
+
+        assert_eq!("0 false", struct_2.ref_mut_method(true).await);
+        assert_eq!(2, struct_2.0);
+        assert_eq!(0, struct_3.0);
+        assert_eq!(" true", struct_str.ref_mut_method(true).await);
+        assert_eq!("", struct_str.0);
+    }
+
+    #[tokio::test]
+    async fn and_return_mocked_then_returns_mocking_result() {
+        let mut struct_2 = Struct(2u8);
+        let mut struct_str = Struct("str");
+        unsafe {
+            Struct::<u8>::ref_mut_method.mock_raw(|a, b| {
+                MockResult::Return(Box::pin(async move { format!("mocked {} {}", a.0, b) }))
+            });
+        }
+
+        assert_eq!("mocked 2 true", struct_2.ref_mut_method(true).await);
+        assert_eq!(2, struct_2.0);
+        assert_eq!(" true", struct_str.ref_mut_method(true).await);
+        assert_eq!("", struct_str.0);
+    }
+}
+
+mod and_method_is_val_method {
+    use super::*;
+
+    #[tokio::test]
+    async fn and_not_mocked_then_runs_normally() {
+        assert_eq!("2 true", Struct(2u8).val_method(true).await);
+        assert_eq!("abc true", Struct("abc").val_method(true).await);
+    }
+
+    #[tokio::test]
+    async fn and_continue_mocked_then_runs_with_modified_args() {
+        unsafe {
+            Struct::<u8>::val_method.mock_raw(move |_, b| MockResult::Continue((Struct(3u8), !b)));
+        }
+
+        assert_eq!("3 false", Struct(2u8).val_method(true).await);
+        assert_eq!("abc true", Struct("abc").val_method(true).await);
+    }
+
+    #[tokio::test]
+    async fn and_return_mocked_then_returns_mocking_result() {
+        unsafe {
+            Struct::<u8>::val_method.mock_raw(|a, b| {
+                MockResult::Return(Box::pin(async move { format!("mocked {} {}", a.0, b) }))
+            });
+        }
+
+        assert_eq!("mocked 2 true", Struct(2u8).val_method(true).await);
+        assert_eq!("abc true", Struct("abc").val_method(true).await);
+    }
+}

--- a/tests/mocking_methods_async/when_struct_regular_method_generic_async.rs
+++ b/tests/mocking_methods_async/when_struct_regular_method_generic_async.rs
@@ -1,0 +1,187 @@
+use super::*;
+
+struct Struct(u8);
+
+#[mockable]
+impl Struct {
+    async fn static_method<T: Display + Send>(arg: bool, method_generic: T) -> String {
+        format!("{} {}", arg, method_generic)
+    }
+
+    async fn ref_method<T: Display + Send>(&self, arg: bool, method_generic: T) -> String {
+        format!("{} {} {}", self.0, arg, method_generic)
+    }
+
+    async fn ref_mut_method<T: Display + Send>(&mut self, arg: bool, method_generic: T) -> String {
+        self.0 *= 2;
+        format!("{} {} {}", self.0, arg, method_generic)
+    }
+
+    async fn val_method<T: Display + Send>(self, arg: bool, method_generic: T) -> String {
+        format!("{} {} {}", self.0, arg, method_generic)
+    }
+}
+
+mod and_method_is_static {
+    use super::*;
+
+    #[tokio::test]
+    async fn and_not_mocked_then_runs_normally() {
+        assert_eq!("true 1.5", Struct::static_method(true, 1.5f32).await);
+        assert_eq!("true abc", Struct::static_method(true, "abc").await);
+    }
+
+    #[tokio::test]
+    async fn and_continue_mocked_then_runs_with_modified_args_for_mocked_type_only() {
+        unsafe {
+            Struct::static_method::<f32>.mock_raw(|a, b| MockResult::Continue((!a, b + 1.)));
+        }
+
+        assert_eq!("false 3.5", Struct::static_method(true, 2.5f32).await);
+        assert_eq!("true abc", Struct::static_method(true, "abc").await);
+    }
+
+    #[tokio::test]
+    async fn and_return_mocked_then_returns_mocking_result_for_mocked_type_only() {
+        unsafe {
+            Struct::static_method::<f32>.mock_raw(|a, b| {
+                MockResult::Return(Box::pin(async move { format!("mocked {} {}", a, b) }))
+            });
+        }
+
+        assert_eq!("mocked true 2.5", Struct::static_method(true, 2.5f32).await);
+        assert_eq!("true abc", Struct::static_method(true, "abc").await);
+    }
+}
+
+mod and_method_is_ref_method {
+    use super::*;
+
+    #[tokio::test]
+    async fn and_not_mocked_then_runs_normally() {
+        assert_eq!("2 true 1.5", Struct(2).ref_method(true, 1.5f32).await);
+        assert_eq!("2 true abc", Struct(2).ref_method(true, "abc").await);
+    }
+
+    #[tokio::test]
+    async fn and_continue_mocked_then_runs_with_modified_args() {
+        let struct_2 = Struct(2);
+        let struct_3 = Struct(3);
+        unsafe {
+            Struct::ref_method::<f32>
+                .mock_raw(|_, b, c| MockResult::Continue((&struct_3, !b, c + 1.)));
+        }
+
+        assert_eq!("3 false 2.5", struct_2.ref_method(true, 1.5f32).await);
+        assert_eq!(2, struct_2.0);
+        assert_eq!(3, struct_3.0);
+        assert_eq!("2 true abc", Struct(2).ref_method(true, "abc").await);
+    }
+
+    #[tokio::test]
+    async fn and_return_mocked_then_returns_mocking_result() {
+        let struct_2 = Struct(2);
+        unsafe {
+            Struct::ref_method::<f32>.mock_raw(|a, b, c| {
+                MockResult::Return(Box::pin(
+                    async move { format!("mocked {} {} {}", a.0, b, c) },
+                ))
+            });
+        }
+
+        assert_eq!("mocked 2 true 1.5", struct_2.ref_method(true, 1.5f32).await);
+        assert_eq!(2, struct_2.0);
+        assert_eq!("2 true abc", Struct(2).ref_method(true, "abc").await);
+    }
+}
+
+mod and_method_is_ref_mut_method {
+    use super::*;
+
+    #[tokio::test]
+    async fn and_not_mocked_then_runs_normally() {
+        let mut struct_2 = Struct(2);
+        let mut struct_4 = Struct(4);
+
+        assert_eq!("4 true 1.5", struct_2.ref_mut_method(true, 1.5f32).await);
+        assert_eq!(4, struct_2.0);
+        assert_eq!("8 true abc", struct_4.ref_mut_method(true, "abc").await);
+        assert_eq!(8, struct_4.0);
+    }
+
+    #[tokio::test]
+    async fn and_continue_mocked_then_runs_with_modified_args() {
+        let mut struct_2 = Struct(2);
+        let struct_3 = Struct(3);
+        let mut struct_4 = Struct(4);
+        unsafe {
+            Struct::ref_mut_method::<f32>
+                .mock_raw(|_, b, c| MockResult::Continue((as_mut(&struct_3), !b, c + 1.)));
+        }
+
+        assert_eq!("6 false 2.5", struct_2.ref_mut_method(true, 1.5f32).await);
+        assert_eq!(2, struct_2.0);
+        assert_eq!(6, struct_3.0);
+        assert_eq!("8 true abc", struct_4.ref_mut_method(true, "abc").await);
+        assert_eq!(8, struct_4.0);
+    }
+
+    #[tokio::test]
+    async fn and_return_mocked_then_returns_mocking_result() {
+        let mut struct_2 = Struct(2);
+        let mut struct_4 = Struct(4);
+        unsafe {
+            Struct::ref_mut_method::<f32>.mock_raw(|a, b, c| {
+                MockResult::Return(Box::pin(
+                    async move { format!("mocked {} {} {}", a.0, b, c) },
+                ))
+            });
+        }
+
+        assert_eq!(
+            "mocked 2 true 1.5",
+            struct_2.ref_mut_method(true, 1.5f32).await
+        );
+        assert_eq!(2, struct_2.0);
+        assert_eq!("8 true abc", struct_4.ref_mut_method(true, "abc").await);
+        assert_eq!(8, struct_4.0);
+    }
+}
+
+mod and_method_is_val_method {
+    use super::*;
+
+    #[tokio::test]
+    async fn and_not_mocked_then_runs_normally() {
+        assert_eq!("2 true 1.5", Struct(2).val_method(true, 1.5f32).await);
+        assert_eq!("2 true abc", Struct(2).val_method(true, "abc").await);
+    }
+
+    #[tokio::test]
+    async fn and_continue_mocked_then_runs_with_modified_args() {
+        unsafe {
+            Struct::val_method::<f32>
+                .mock_raw(move |_, b, c| MockResult::Continue((Struct(3), !b, c + 1.)));
+        }
+
+        assert_eq!("3 false 2.5", Struct(2).val_method(true, 1.5f32).await);
+        assert_eq!("2 true abc", Struct(2).val_method(true, "abc").await);
+    }
+
+    #[tokio::test]
+    async fn and_return_mocked_then_returns_mocking_result() {
+        unsafe {
+            Struct::val_method::<f32>.mock_raw(|a, b, c| {
+                MockResult::Return(Box::pin(
+                    async move { format!("mocked {} {} {}", a.0, b, c) },
+                ))
+            });
+        }
+
+        assert_eq!(
+            "mocked 2 true 1.5",
+            Struct(2).val_method(true, 1.5f32).await
+        );
+        assert_eq!("2 true abc", Struct(2).val_method(true, "abc").await);
+    }
+}

--- a/tests/mocking_methods_async/when_struct_regular_method_regular_async.rs
+++ b/tests/mocking_methods_async/when_struct_regular_method_regular_async.rs
@@ -1,14 +1,52 @@
 use super::*;
-use std::time::Duration;
-use tokio::time::delay_for;
 
-struct Struct(u64);
+struct Struct(u8);
 
 #[mockable]
 impl Struct {
+    async fn static_method(arg: bool) -> String {
+        format!("{}", arg)
+    }
+
     async fn ref_method(&self, arg: bool) -> String {
-        delay_for(Duration::from_secs(self.0)).await;
         format!("{} {}", self.0, arg)
+    }
+
+    async fn ref_mut_method(&mut self, arg: bool) -> String {
+        self.0 *= 2;
+        format!("{} {}", self.0, arg)
+    }
+
+    async fn val_method(self, arg: bool) -> String {
+        format!("{} {}", self.0, arg)
+    }
+}
+
+mod and_async_method_is_static {
+    use super::*;
+
+    #[tokio::test]
+    async fn and_not_mocked_then_runs_normally() {
+        assert_eq!("true", Struct::static_method(true).await);
+    }
+
+    #[tokio::test]
+    async fn and_continue_mocked_then_runs_with_modified_args() {
+        unsafe {
+            Struct::static_method.mock_raw(|a| MockResult::Continue((!a,)));
+        }
+
+        assert_eq!("false", Struct::static_method(true).await);
+    }
+
+    #[tokio::test]
+    async fn and_return_mocked_then_returns_mocking_result() {
+        unsafe {
+            Struct::static_method
+                .mock_raw(|a| MockResult::Return(Box::pin(async move { format!("mocked {}", a) })));
+        }
+
+        assert_eq!("mocked true", Struct::static_method(true).await);
     }
 }
 
@@ -16,15 +54,100 @@ mod and_method_is_ref_method {
     use super::*;
 
     #[tokio::test]
-    async fn and_return_mocked_async_then_returns_mocking_result() {
-        let struct_0 = Struct(2);
+    async fn and_not_mocked_then_runs_normally() {
+        assert_eq!("2 true", Struct(2).ref_method(true).await);
+    }
+
+    #[tokio::test]
+    async fn and_continue_mocked_then_runs_with_modified_args() {
+        let struct_2 = Struct(2);
+        let struct_3 = Struct(3);
+        unsafe {
+            Struct::ref_method.mock_raw(|_, b| MockResult::Continue((&struct_3, !b)));
+        }
+
+        assert_eq!("3 false", struct_2.ref_method(true).await);
+        assert_eq!(2, struct_2.0);
+        assert_eq!(3, struct_3.0);
+    }
+
+    #[tokio::test]
+    async fn and_return_mocked_then_returns_mocking_result() {
+        let struct_2 = Struct(2);
         unsafe {
             Struct::ref_method.mock_raw(|a, b| {
                 MockResult::Return(Box::pin(async move { format!("mocked {} {}", a.0, b) }))
             });
         }
 
-        assert_eq!("mocked 2 true", struct_0.ref_method(true).await);
-        assert_eq!(2, struct_0.0);
+        assert_eq!("mocked 2 true", struct_2.ref_method(true).await);
+        assert_eq!(2, struct_2.0);
+    }
+}
+
+mod and_async_method_is_ref_mut_method {
+    use super::*;
+
+    #[tokio::test]
+    async fn and_not_mocked_then_runs_normally() {
+        let mut struct_2 = Struct(2);
+
+        assert_eq!("4 true", struct_2.ref_mut_method(true).await);
+        assert_eq!(4, struct_2.0);
+    }
+
+    #[tokio::test]
+    async fn and_continue_mocked_then_runs_with_modified_args() {
+        let mut struct_2 = Struct(2);
+        let struct_3 = Struct(3);
+        unsafe {
+            Struct::ref_mut_method.mock_raw(|_, b| MockResult::Continue((as_mut(&struct_3), !b)));
+        }
+
+        assert_eq!("6 false", struct_2.ref_mut_method(true).await);
+        assert_eq!(2, struct_2.0);
+        assert_eq!(6, struct_3.0);
+    }
+
+    #[tokio::test]
+    async fn and_return_mocked_then_returns_mocking_result() {
+        let mut struct_2 = Struct(2);
+        unsafe {
+            Struct::ref_mut_method.mock_raw(|a, b| {
+                MockResult::Return(Box::pin(async move { format!("mocked {} {}", a.0, b) }))
+            });
+        }
+
+        assert_eq!("mocked 2 true", struct_2.ref_mut_method(true).await);
+        assert_eq!(2, struct_2.0);
+    }
+}
+
+mod and_async_method_is_val_method {
+    use super::*;
+
+    #[tokio::test]
+    async fn and_not_mocked_then_runs_normally() {
+        assert_eq!("2 true", Struct(2).val_method(true).await);
+    }
+
+    #[tokio::test]
+    async fn and_continue_mocked_then_runs_with_modified_args() {
+        unsafe {
+            Struct::val_method.mock_raw(move |_, b| MockResult::Continue((Struct(3), !b)));
+        }
+
+        assert_eq!("3 false", Struct(2).val_method(true).await);
+    }
+
+    #[tokio::test]
+    async fn and_return_mocked_then_returns_mocking_result() {
+        unsafe {
+            Struct::val_method.mock_raw(|a, b| {
+                MockResult::Return(Box::pin(async move { format!("mocked {} {}", a.0, b) }))
+            });
+        }
+
+        assert_eq!("mocked 2 true", Struct(2).val_method(true).await);
     }
 }

--- a/tests/mocking_methods_async/when_struct_regular_method_regular_async.rs
+++ b/tests/mocking_methods_async/when_struct_regular_method_regular_async.rs
@@ -1,0 +1,30 @@
+use super::*;
+use std::time::Duration;
+use tokio::time::delay_for;
+
+struct Struct(u64);
+
+#[mockable]
+impl Struct {
+    async fn ref_method(&self, arg: bool) -> String {
+        delay_for(Duration::from_secs(self.0)).await;
+        format!("{} {}", self.0, arg)
+    }
+}
+
+mod and_method_is_ref_method {
+    use super::*;
+
+    #[tokio::test]
+    async fn and_return_mocked_async_then_returns_mocking_result() {
+        let struct_0 = Struct(2);
+        unsafe {
+            Struct::ref_method.mock_raw(|a, b| {
+                MockResult::Return(Box::pin(async move { format!("mocked {} {}", a.0, b) }))
+            });
+        }
+
+        assert_eq!("mocked 2 true", struct_0.ref_method(true).await);
+        assert_eq!(2, struct_0.0);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

This PR adds support for mocking async methods by adopting a similar strategy to [async-trait](https://github.com/dtolnay/async-trait). Still very much a work-in-progress, but it should work with simple methods.

Closes #52