### PR TITLE
Fixed compilation of latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(fn_traits, unboxed_closures)]
+#![feature(fn_traits, tuple_trait, unboxed_closures)]
 
 //! Mocking framework for Rust (currently only nightly)
 //!

--- a/tests/injecting.rs
+++ b/tests/injecting.rs
@@ -1,4 +1,4 @@
-#![feature(const_fn, proc_macro_hygiene)]
+#![feature(proc_macro_hygiene)]
 
 // Test if injecting works even if mocktopus is aliased
 extern crate mocktopus as mocktopus_aliased;


### PR DESCRIPTION
- Caused by `Fn` and related traits [now requiring their arguments to impl `Tuple`](https://github.com/rust-lang/rust/pull/99943).
- This PR adds constraints where needed to also require `Tuple` to be implemented.
- The feature gate `const_fn` no longer exists and was causing a compilation error, and this PR also removes its usage.
- Not very familiar with the internals of this crate, so please let me know if this PR should fix anything differently!
- Resolves #71 